### PR TITLE
fix mangled project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ work, are complete, nor that they do not cause any harm to your system or your a
 * [gem-fog-hetznercloud](https://github.com/elconas/gem-fog-hetznercloud) — Fog provider gem to support Hetzner Cloud. 
 * [hcloud-csi-driver](https://github.com/apricote/hcloud-csi-driver) — A Container Storage Interface (CSI) Driver for Hetzner Cloud Volumes. 
 * [hcloud-fip-controller](https://github.com/cbeneke/hcloud-fip-controller) — Kubernetes controller to (re-)assign floating IPs to Hetzner Cloud instances. 
-* [hetzner-cloud-ip-floater-kubernetes-controller](https://github.com/costela/hcloud-ip-floater) — Kubernetes controller to attach hcloud floating IPs to services&#039; nodes. 
+* [hcloud-ip-floater](https://github.com/costela/hcloud-ip-floater) — Kubernetes controller to attach hcloud floating IPs to services&#039; nodes. 
 * [itop-datacollector-for-hetzner-cloud](https://github.com/itomig-de/itomig-hetzner-collector) — This stand-alone application collects information from Hetzner projects in order to automatically synchronize the farms and virtual machines in iTop.
 
 iTop is a web based open source tool for IT service management tasks. 


### PR DESCRIPTION
Somehow during the merging of #27 the project name got mangled. The PR looks OK, the actually merged code does not. :man_shrugging:   
Unfortunately I only noticed it now.