### PR TITLE
Add GitLab-Hetzner-Runner project

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ work, are complete, nor that they do not cause any harm to your system or your a
 * [hetzner-cloud-api-mock](https://github.com/LKDevelopment/hetzner-cloud-api-mock) — A basic mock server that makes testing the Hetzner Cloud API a breeze. 
 * [hetzner-kube](https://github.com/xetys/hetzner-kube) — This project contains a CLI tool to easily provision kubernetes clusters on Hetzner Cloud. 
 * [kubeone](https://github.com/kubermatic/kubeone) — Kubermatic KubeOne automates cluster operations on hetzner cloud. KubeOne can install high-available (HA) master clusters as well single master clusters. 
-* [gitlab-hetzner-runner](https://git.shivering-isles.com/shivering-isles/gitlab-hetzner-runner) — A version of the gitlab-runner base image, that allows the usage of Hetzner Cloud instances for GitLab CI.
+* [gitlab-hetzner-runner](https://github.com/SISheogorath/gitlab-hetzner-runner-mirror) (mirror) — A version of the gitlab-runner base image, that allows the usage of Hetzner Cloud instances for GitLab CI. [Original project](https://git.shivering-isles.com/shivering-isles/gitlab-hetzner-runner)
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ work, are complete, nor that they do not cause any harm to your system or your a
 * [hetzner-cloud-api-mock](https://github.com/LKDevelopment/hetzner-cloud-api-mock) — A basic mock server that makes testing the Hetzner Cloud API a breeze. 
 * [hetzner-kube](https://github.com/xetys/hetzner-kube) — This project contains a CLI tool to easily provision kubernetes clusters on Hetzner Cloud. 
 * [kubeone](https://github.com/kubermatic/kubeone) — Kubermatic KubeOne automates cluster operations on hetzner cloud. KubeOne can install high-available (HA) master clusters as well single master clusters. 
+* [gitlab-hetzner-runner](https://git.shivering-isles.com/shivering-isles/gitlab-hetzner-runner) — A version of the gitlab-runner base image, that allows the usage of Hetzner Cloud instances for GitLab CI.
 
 ## Integrations
 


### PR DESCRIPTION
The project can be considered rather stable, worked almost flawless for the entire time of its existence and is maintained by me. And official image is also available at [quay.io/shivering-isles/gitlab-hetzner-runner](https://quay.io/repository/shivering-isles/gitlab-hetzner-runner?tab=tags).