### PR TITLE
Add hobby-kube

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ work, are complete, nor that they do not cause any harm to your system or your a
 * [hetzner-kube](https://github.com/xetys/hetzner-kube) — This project contains a CLI tool to easily provision kubernetes clusters on Hetzner Cloud. 
 * [hetzner-load-balancer-prometheus-exporter](https://github.com/infraduckture/hetzner-load-balancer-prometheus-exporter) — Exports metrics from Hetzner Load Balancer for consumption by Prometheus 
 * [hetzner-rescaler](https://github.com/jonamat/hetzner-rescaler) — Lightweight CLI tool to programmatically rescale your Hetzner Cloud server. 
+* [hobby-kube](https://github.com/hobby-kube/guide) — Fully automated cluster setup using Terraform, good balance between resilience and cost, and therefore a great starting point for hobbyists or to build a professional setup with a reasonable foundation
 * [kubeone](https://github.com/kubermatic/kubeone) — Kubermatic KubeOne automates cluster operations on hetzner cloud. KubeOne can install high-available (HA) master clusters as well single master clusters. 
 * [kubernetes-hetzner-keepalived](https://github.com/schemen/kubernetes-hetzner-keepalived) — K8s deployment and image to create a keepalived ip failover with the floating ip feature. 
 


### PR DESCRIPTION
I found hobby-kube ([guide](https://github.com/hobby-kube/guide), [actual Terraform modules](https://github.com/hobby-kube/provisioning)) to be a very simple, yet great foundation for my personal Kubernetes clusters. Definitely worth listing. "For hobbyists" is an understatement in my opinion, since the setup is secure and very modular.