### PR TITLE
Add Firezone to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ work, are complete, nor that they do not cause any harm to your system or your a
 * [terraform-kubernetes-hcloud-controller-manager](https://github.com/colinwilson/terraform-kubernetes-hcloud-controller-manager) — A simple module to provision the Hetzner Cloud Controller Manager (With Network &amp; Load Balancer Support) inside a Kubernetes cluster running on Hetzner Cloud. See the variables file for the available configuration options. Please note that this module requires Kubernetes 1.16 or newer. 
 * [ui-driver-hetzner](https://github.com/mxschmitt/ui-driver-hetzner) — Rancher UI driver for the Hetzner Cloud docker-machine-driver 
 * [versio-io](https://www.versio.io/import-hetzner-cloud-cmdb-configuration-item.html) — Integration of Hetzner Cloud configuration items (CI) in the full stack Versio.io configuration management database (CMDB). 
+* [Firezone](https://www.firezone.dev/) - Self-hosted VPN server using WireGuard. Supports MFA, SSO, and has easy deployment options on Hetzner Cloud.
 
 ## License
 


### PR DESCRIPTION
Decent way to add a VPN to Hetzner cloud. Has good docs (https://docs.firezone.dev/), but could use a guide for Hetzner.