### PR TITLE
Add hetzner-k3s

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ work, are complete, nor that they do not cause any harm to your system or your a
 * [kops](https://github.com/kubernetes/kops) — Kubernetes Operations (kOps) automates Kubernetes cluster installation, upgrades and management 
 * [kubeone](https://github.com/kubermatic/kubeone) — Kubermatic KubeOne automates cluster operations on hetzner cloud. KubeOne can install high-available (HA) master clusters as well single master clusters. 
 * [kubernetes-hetzner-keepalived](https://github.com/schemen/kubernetes-hetzner-keepalived) — K8s deployment and image to create a keepalived ip failover with the floating ip feature. 
+* [hetzner-k3s](https://github.com/janosmiko/hetzner-k3s) — CLI tool to install and manage production grade lightweight Kubernetes (k3s) clusters in 5 minutes in Hetzner. Features: Hetzner CCM and CSI support, HA, Multiple Worker Pools, Autoscaling etc.
 
 ## Integrations
 


### PR DESCRIPTION
This is a CLI tool to quickly create and manage Kubernetes clusters in Hetzner Cloud using the lightweight Kubernetes distribution k3s from Rancher.

Using this tool, creating a highly available k3s cluster with 3 masters for the control plane and worker nodes (with autoscaling support) takes about a couple of minutes only. 
Including:
- creating the infra resources (servers, private network, firewall, load balancer for the API server for HA clusters)
- deploying k3s to the nodes
- installing the Hetzner Cloud Controller Manager to provision load balancers right away
- installing the Hetzner CSI Driver to provision persistent volumes using Hetzner's block storage
- installing the Rancher System Upgrade Controller to make upgrades to a newer version of k3s easy and quick
- installing the Kubernetes Cluster Autoscaler to make the cluster autoscaling possible