### PR TITLE
Add hetzner-cloud-openapi-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ work, are complete, nor that they do not cause any harm to your system or your a
 
 - [hcloud-js](https://github.com/dennisbruner/hcloud-js) — A Node.js module for the Hetzner Cloud API — ⚠️ Deprecated
 - [hcloud-nodejs](https://github.com/leonspors/hcloud-nodejs) — hcloud-nodejs is a node.js package for Hetzner cloud that can be used to manage your projects.
+- [hetzner-cloud-openapi-client](https://codeberg.org/small-tech/hetzner-cloud-openapi-client) - Hetzner Cloud OpenAPI Client generated from the official specification using Massimo.
 
 ### Kotlin
 


### PR DESCRIPTION
This is a new Hetzner Cloud OpenAPI Client generated from the official specification using Massimo.

The aim is to have a zero-maintenance Node.js client that is always up-to-date with the official specification.

(Of the other two Node.js libraries, one is deprecated and the other was last updated seven years ago so it might be an idea to consider whether they should be removed.)

PS. Thanks for making and sharing this list 💕