### PR TITLE
Add Cloud Inefficiency Audit to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ work, are complete, nor that they do not cause any harm to your system or your a
 - **[setup-hcloud](https://github.com/hetznercloud/setup-hcloud) — GitHub action to install the Hetzner Cloud CLI.**
 - [1Password Shell Plugin](https://developer.1password.com/docs/cli/shell-plugins/hetzner-cloud/) — The Hetzner Cloud shell plugin allows you to use 1Password to securely authenticate hcloud CLI with your fingerprint, Apple Watch, or system authentication, rather than storing your credentials in plaintext.
 - [Ansible Role hcloud](https://github.com/ngine-io/ansible-role-hcloud) — Ansible Role for managing hcloud cloud resources.
+- [Cloud Inefficiency Audit](https://github.com/gelkao/cloud-inefficiency-audit) — Local CLI that reads your Hetzner Cloud invoices and shows how much you overpay versus the cheapest equivalent server type; runs fully offline, no account or login.
 - [HC Volume Backup](https://gitlab.com/martinboehmer/hc-volume-backup) — Bash script to backup Hetzner Cloud Volumes. Automatically creates volumes for backups and maintains a defined number of them.
 - [HCloud Menubar](https://github.com/geberl/hcloud-menubar) — A lightweight macOS menu bar app for managing Hetzner Cloud resources
 - [Hcloud Snapshot-as-Backup](https://github.com/fbrettnich/hcloud-snapshot-as-backup) — Hetzner Cloud - Automatic Snapshots as Backups for more flexibility


### PR DESCRIPTION
Adds Cloud Inefficiency Audit (https://github.com/gelkao/cloud-inefficiency-audit) to the Tools section.

A local, offline CLI (Bash + sqlite3, Apache-2.0) that reads your Hetzner Cloud
invoices and reports how much you overpay versus the cheapest equivalent server
type - no account, no login, nothing uploaded. Ships a synthetic example fleet so
it can be tried on a fresh clone with no account.

Slotted alphabetically in Tools. Previously proposed as issue #159; reopening as a
PR since additions land through PRs.